### PR TITLE
Fixed LinkTextTouchAttributes Bug

### DIFF
--- a/CCHLinkTextView Example/CCHLinkTextView Example/ViewController.m
+++ b/CCHLinkTextView Example/CCHLinkTextView Example/ViewController.m
@@ -84,6 +84,8 @@
     
     [self.longPressGestureRecognizer requireGestureRecognizerToFail:linkTextView.linkGestureRecognizer];
     linkTextView.linkDelegate = self;
+    linkTextView.linkTextAttributes = @{NSForegroundColorAttributeName : [UIColor blueColor]};
+    linkTextView.linkTextTouchAttributes = @{NSBackgroundColorAttributeName : [UIColor whiteColor], NSForegroundColorAttributeName : [UIColor orangeColor]};
 }
 
 - (void)linkTextView:(CCHLinkTextView *)linkTextView didTapLinkWithValue:(id)value

--- a/CCHLinkTextView/CCHLinkTextView.h
+++ b/CCHLinkTextView/CCHLinkTextView.h
@@ -38,7 +38,7 @@ extern NSString *const CCHLinkAttributeName;
 @property (nonatomic, weak) id<CCHLinkTextViewDelegate> linkDelegate;
 
 /** `NSAttributedString` attributes applied to links. */
-@property(nonatomic, copy) NSDictionary *linkTextAttributes NS_AVAILABLE_IOS(7_0);
+@property (nonatomic, copy) NSDictionary *linkTextAttributes NS_AVAILABLE_IOS(7_0);
 /** `NSAttributedString` attributes applied to links when touched. */
 @property (nonatomic, copy) NSDictionary *linkTextTouchAttributes;
 

--- a/CCHLinkTextView/CCHLinkTextView.m
+++ b/CCHLinkTextView/CCHLinkTextView.m
@@ -109,14 +109,33 @@ NSString *const CCHLinkAttributeName = @"CCHLinkAttributeName";
     return image;
 }
 
+- (void)setLinkTextAttributes:(NSDictionary *)linkTextAttributes
+{
+    super.linkTextAttributes = linkTextAttributes;
+    [self setAttributedText:[self attributedText] skipLinkTextAttributes:NO];
+}
+
+- (void)setLinkTextTouchAttributes:(NSDictionary *)linkTextTouchAttributes
+{
+    _linkTextTouchAttributes = linkTextTouchAttributes;
+    [self setAttributedText:[self attributedText] skipLinkTextAttributes:NO];
+}
+
 - (void)setAttributedText:(NSAttributedString *)attributedText
 {
+    [self setAttributedText:attributedText skipLinkTextAttributes:NO];
+}
+
+- (void)setAttributedText:(NSAttributedString *)attributedText skipLinkTextAttributes:(BOOL)skipLinkTextAttributes
+{
     NSMutableAttributedString *mutableAttributedText = [attributedText mutableCopy];
-    [mutableAttributedText enumerateAttribute:CCHLinkAttributeName inRange:NSMakeRange(0, attributedText.length) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
-        if (value) {
-            [mutableAttributedText addAttributes:self.linkTextAttributes range:range];
-        }
-    }];
+    if (!skipLinkTextAttributes) {
+        [mutableAttributedText enumerateAttribute:CCHLinkAttributeName inRange:NSMakeRange(0, attributedText.length) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
+            if (value) {
+                [mutableAttributedText addAttributes:self.linkTextAttributes range:range];
+            }
+        }];
+    }
     
     [super setAttributedText:mutableAttributedText];
 }
@@ -224,8 +243,11 @@ NSString *const CCHLinkAttributeName = @"CCHLinkAttributeName";
 {
     [self enumerateLinkRangesContainingLocation:location usingBlock:^(NSRange range) {
         NSMutableAttributedString *attributedText = [self.attributedText mutableCopy];
+        for (NSString *attribute in self.linkTextAttributes) {
+            [attributedText removeAttribute:attribute range:range];
+        }
         [attributedText addAttributes:self.linkTextTouchAttributes range:range];
-        self.attributedText = attributedText;
+        [self setAttributedText:attributedText skipLinkTextAttributes:YES];
     }];
 }
 
@@ -237,7 +259,7 @@ NSString *const CCHLinkAttributeName = @"CCHLinkAttributeName";
             [attributedText removeAttribute:attribute range:range];
         }
         [attributedText addAttributes:self.linkTextAttributes range:range];
-        self.attributedText = attributedText;
+        [self setAttributedText:attributedText skipLinkTextAttributes:YES];
     }];
 }
 


### PR DESCRIPTION
Fixed a bug where LinkTextTouchAttributes would be ignored if
LinkTextAttributes clashed.

For example if you set the LinkTextAttributes to: `@{NSForegroundColorAttributeName : [UIColor blueColor]}` and the LinkTextTouchAttributes to `@{NSForegroundColorAttributeName : [UIColor orangeColor]}` the link would stay blue even when tapped. The code I've added makes sure the LinkTextAttributes are removed when the link is tapped and then added again when the touch has finished.
