### PR TITLE
Added a property "linkCornerRadius" to allow rounded rect

### DIFF
--- a/CCHLinkTextView Example/CCHLinkTextView Example/ViewController.m
+++ b/CCHLinkTextView Example/CCHLinkTextView Example/ViewController.m
@@ -85,7 +85,9 @@
     [self.longPressGestureRecognizer requireGestureRecognizerToFail:linkTextView.linkGestureRecognizer];
     linkTextView.linkDelegate = self;
     linkTextView.linkTextAttributes = @{NSForegroundColorAttributeName : [UIColor blueColor]};
-    linkTextView.linkTextTouchAttributes = @{NSForegroundColorAttributeName : [UIColor orangeColor]};
+    linkTextView.linkTextTouchAttributes = @{NSForegroundColorAttributeName : [UIColor orangeColor],
+                                             NSBackgroundColorAttributeName: [UIColor darkGrayColor]};
+    linkTextView.linkCornerRadius = 4.0f;
 }
 
 - (void)linkTextView:(CCHLinkTextView *)linkTextView didTapLinkWithValue:(id)value

--- a/CCHLinkTextView/CCHLinkTextView.h
+++ b/CCHLinkTextView/CCHLinkTextView.h
@@ -53,6 +53,9 @@ extern NSString *const CCHLinkAttributeName;
 /** The gesture recognizer used to detect links in this text view. */
 @property (nonatomic, readonly) CCHLinkGestureRecognizer *linkGestureRecognizer;
 
+/** The corner radius of the rounded rectangle that is shown when link touched. (default = 0 point) */
+@property (nonatomic) CGFloat linkCornerRadius;
+
 /** 
  For the given ranges, enumerates all view rectangles that cover each range.
  @param ranges array of ranges.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The first method is called for taps, the second for long presses.
 
 To style the links, use `linkTextAttributes` and `linkTextTouchAttributes`. These dictionaries contain `NSAttributedString` attributes applied to links as they appear normally and when touched. By default, `linkTextAttributes` sets the tint color as foreground color and `linkTextTouchAttributes` a light gray background. 
 
+Use `linkCornerRadius` to make the background on touch as a rounded rectangle.
+
 ### Advanced settings
 
 There are a few settings to allow you to adjust `CCHLinkTextView`'s behavior:


### PR DESCRIPTION
Draw a rounded rect around link text when tapped, similar to the
original iOS design.

![ios simulator screen shot feb 9 2015 1 57 18 pm](https://cloud.githubusercontent.com/assets/746943/6116686/961541fa-b063-11e4-86b1-d81d41eaf691.png)
